### PR TITLE
Add default value for collection options

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -88,7 +88,7 @@ async function updateMutableProperties({
   return { collection: updated, message: false }
 }
 
-async function collection({ connection, name, type = 'document', options }) {
+async function collection({ connection, name, type = 'document', options = {} }) {
   const collection = connection.collection(name)
   let exists
   try {


### PR DESCRIPTION
This commit fixes an issue where no options are passed and a collection
exists. This passed undefined into a update function which then looked
for options to update, resulting in the following error:

```
TypeError: Cannot read property 'waitForSync' of undefined
```
This commit reproduces the error in a test and provides a default.