### PR TITLE
Add connectTo that doesn't require db description

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,19 @@ await cursor.all()
 await drop()
 ```
 
+For those moments when you really just want to connect, there is also `connectTo`.
+
+```javascript
+const { query, drop, truncate, transaction } = await connectTo({
+  url: 'http://localhost:8529', // default
+  databaseName: 'mydb',
+  as: {
+    username: 'mike', // the user the returned funtions should operate with
+    password: 'secret',
+  },
+})
+```
+
 ## Issues
 
 Currently arango-tools can create a database, a document/edge collection, a search view, delimiter analyzer and a GeoIndex.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 const { dbNameFromFile, ArangoTools } = require('./src/utils.js')
 const { ensure } = require('./src/ensure.js')
+const { connectTo } = require('./src/connectTo.js')
 module.exports.dbNameFromFile = dbNameFromFile
 module.exports.ArangoTools = ArangoTools
 module.exports.ensure = ensure
+module.exports.connectTo = connectTo

--- a/src/__tests__/connectTo.test.js
+++ b/src/__tests__/connectTo.test.js
@@ -1,0 +1,49 @@
+const { Database } = require('arangojs')
+const { dbNameFromFile } = require('../utils')
+const { connectTo } = require('../connectTo')
+const {
+  ARANGOTOOLS_DB_URL: url,
+  ARANGOTOOLS_DB_PASSWORD: rootPassword,
+} = process.env
+
+describe('connectTo', () => {
+  it('returns db accessors', async () => {
+    const name = dbNameFromFile(__filename)
+    const sys = new Database({ url })
+    await sys.login('root', rootPassword)
+
+    // make the database
+    await sys.createDatabase(name, {
+      users: [{ user: name, passwd: 'test', active: true }],
+    })
+
+    const accessors = await connectTo({
+      databaseName: name,
+      as: {
+        username: name,
+        password: 'test',
+      },
+    })
+
+    await expect(accessors).toMatchObject({
+      query: expect.any(Function),
+      truncate: expect.any(Function),
+      drop: expect.any(Function),
+      transaction: expect.any(Function),
+    })
+  })
+})
+
+describe('connectTo', () => {
+  it('throws when it cannot connect', async () => {
+    await expect(
+      connectTo({
+        databaseName: 'does-not-exist',
+        as: {
+          username: 'mike',
+          password: 'test',
+        },
+      }),
+    ).rejects.toThrow('no such database')
+  })
+})

--- a/src/connectTo.js
+++ b/src/connectTo.js
@@ -1,0 +1,10 @@
+const { connect } = require('./connect')
+const { databaseAccessors } = require('./databaseAccessors')
+
+async function connectTo(options) {
+  const { connection, message } = await connect(options)
+  if (message) throw new Error(message)
+  return databaseAccessors({ connection })
+}
+
+module.exports.connectTo = connectTo


### PR DESCRIPTION
This commit adds the connectTo function, which just wraps the `connect`
and `databaseAccessor` functions.